### PR TITLE
feat: add more EEG input formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.3 — Additional EEG formats
+- Support BrainVision `.vhdr`, EGI `.mff`/`.raw`, MNE `.fif`, and `.gdf` files.
+- Update CLI help, README, and tests to cover new formats.
+
+## 0.1.4 — Modular loader plugins
+- Split each EEG format reader into its own plugin module for maintainability.
+- Document the plugin registry and update tests accordingly.
+
 ## 0.1.2 — Restore default viewer behavior
 - Default behavior now opens the MNE-QT Browser when a file is provided.
 - Introduce `--view/--no-view` toggle (default: `--view`).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🧠 AutoCleanEEG-View
 
-**AutoCleanEEG-View** is a simple yet powerful tool for neuroscientists, researchers, and EEG enthusiasts to visualize EEGLAB `.set`, `.edf`, and `.bdf` files using the modern MNE-QT Browser.
+**AutoCleanEEG-View** is a simple yet powerful tool for neuroscientists, researchers, and EEG enthusiasts to visualize EEG files such as EEGLAB `.set`, `.edf`, `.bdf`, BrainVision `.vhdr`, EGI `.mff`/`.raw`, and MNE `.fif` using the modern MNE-QT Browser.
 
 ## ✨ Features
 
@@ -9,6 +9,7 @@
 - **Automatic Channel Type Detection**: Properly handles EEG, EOG, ECG channels
 - **Event Markers**: View annotations and event markers in your recordings
 - **Cross-Platform**: Works on macOS and Linux
+- **Extensible Loaders**: Each format lives in its own plugin module for easy maintenance
 
 ## 🚀 Quick Start
 
@@ -25,10 +26,10 @@ pip install autocleaneeg-view
 autocleaneeg-view path/to/yourfile.set
 
 # Explicitly open the viewer (also supported for clarity)
-autocleaneeg-view path/to/yourfile.set --view
+autocleaneeg-view path/to/yourfile.vhdr --view
 
 # Load without viewing (just validate the file)
-autocleaneeg-view path/to/yourfile.set --no-view
+autocleaneeg-view path/to/yourfile.fif --no-view
 ```
 
 Note: `autoclean-view` remains available as a legacy alias of

--- a/autocleaneeg_view/cli.py
+++ b/autocleaneeg_view/cli.py
@@ -16,7 +16,7 @@ from autocleaneeg_view.viewer import load_eeg_file, view_eeg
     help="Launch the MNE-QT Browser to view the data (default: view; use --no-view to suppress).",
 )
 def main(file, view):
-    """Load and visualize EEG files (.set, .edf, .bdf) using MNE-QT Browser.
+    """Load and visualize EEG files (.set, .edf, .bdf, .vhdr, .fif, .raw, .gdf and optionally .mff) using MNE-QT Browser.
 
     FILE is the path to the EEG file to process.
     """

--- a/autocleaneeg_view/loaders/__init__.py
+++ b/autocleaneeg_view/loaders/__init__.py
@@ -1,0 +1,16 @@
+"""Plugin registry for EEG data loaders."""
+
+from __future__ import annotations
+
+READERS = {}
+
+
+def register_loader(extension: str, reader):
+    """Register a loader for a given file extension."""
+    READERS[extension.lower()] = reader
+
+
+# Import built-in loader plugins so they register themselves
+from . import eeglab, edf, bdf, brainvision, fif, egi, gdf  # noqa: F401,E402
+
+SUPPORTED_EXTENSIONS = tuple(sorted(READERS.keys()))

--- a/autocleaneeg_view/loaders/bdf.py
+++ b/autocleaneeg_view/loaders/bdf.py
@@ -1,0 +1,7 @@
+"""BDF loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".bdf", mne.io.read_raw_bdf)

--- a/autocleaneeg_view/loaders/brainvision.py
+++ b/autocleaneeg_view/loaders/brainvision.py
@@ -1,0 +1,7 @@
+"""BrainVision .vhdr loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".vhdr", mne.io.read_raw_brainvision)

--- a/autocleaneeg_view/loaders/edf.py
+++ b/autocleaneeg_view/loaders/edf.py
@@ -1,0 +1,7 @@
+"""EDF loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".edf", mne.io.read_raw_edf)

--- a/autocleaneeg_view/loaders/eeglab.py
+++ b/autocleaneeg_view/loaders/eeglab.py
@@ -1,0 +1,7 @@
+"""EEGLAB .set loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".set", mne.io.read_raw_eeglab)

--- a/autocleaneeg_view/loaders/egi.py
+++ b/autocleaneeg_view/loaders/egi.py
@@ -1,0 +1,10 @@
+"""EGI .raw and optional .mff loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".raw", mne.io.read_raw_egi)
+
+if hasattr(mne.io, "read_raw_mff"):  # pragma: no cover - optional dependency
+    register_loader(".mff", mne.io.read_raw_mff)

--- a/autocleaneeg_view/loaders/fif.py
+++ b/autocleaneeg_view/loaders/fif.py
@@ -1,0 +1,7 @@
+"""MNE .fif loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".fif", mne.io.read_raw_fif)

--- a/autocleaneeg_view/loaders/gdf.py
+++ b/autocleaneeg_view/loaders/gdf.py
@@ -1,0 +1,7 @@
+"""GDF loader plugin."""
+
+import mne
+
+from . import register_loader
+
+register_loader(".gdf", mne.io.read_raw_gdf)

--- a/docs/additional-formats.mdx
+++ b/docs/additional-formats.mdx
@@ -1,0 +1,38 @@
+---
+title: Additional EEG Format Support
+---
+
+import { Steps, Callout, Diagram } from "nextra/components";
+
+# Additional EEG Format Support
+
+<Callout type="info">
+  Expanded file loading to handle BrainVision <code>.vhdr</code>, EGI <code>.mff</code>/<code>.raw</code>, MNE <code>.fif</code>, and <code>.gdf</code> files in addition to the original <code>.set</code>, <code>.edf</code>, and <code>.bdf</code>.
+</Callout>
+
+<Steps>
+  <Step title="Map extensions to readers">
+    Introduced a lookup table that connects each supported extension with its corresponding <code>mne.io.read_raw_*</code> function. This makes adding future formats straightforward.
+  </Step>
+  <Step title="Adjust CLI and docs">
+    Updated help text and README examples so users know they can open BrainVision, EGI, and other common EEG datasets.
+  </Step>
+  <Step title="Simulate formats in tests">
+    Parameterized unit tests monkey‑patch MNE readers and create temporary files or folders&mdash;note that EGI <code>.mff</code> recordings are directories&mdash;to verify every extension is routed correctly.
+  </Step>
+</Steps>
+
+## Verify the update
+
+```bash
+pip install -e .
+pytest -q
+```
+
+<Diagram>
+.vhdr -> read_raw_brainvision
+.mff/.raw -> read_raw_mff/read_raw_egi
+.fif -> read_raw_fif
+.gdf -> read_raw_gdf
+</Diagram>
+

--- a/docs/format-plugins.mdx
+++ b/docs/format-plugins.mdx
@@ -1,0 +1,38 @@
+---
+title: Loader Plugin Architecture
+---
+
+import { Steps, Callout, Diagram } from "nextra/components";
+
+# Loader Plugin Architecture
+
+<Callout type="info">
+  Each EEG format now has its own plugin module that registers a loader with a central registry.
+</Callout>
+
+<Steps>
+  <Step title="Introduce registry">
+    Built a tiny <code>register_loader</code> helper in <code>autocleaneeg_view.loaders</code> to keep a mapping of extensions to reader functions.
+  </Step>
+  <Step title="Split modules">
+    Created dedicated modules like <code>eeglab.py</code>, <code>brainvision.py</code>, and <code>egi.py</code> under <code>autocleaneeg_view/loaders/</code>. Each calls <code>register_loader</code> with its extension and corresponding <code>mne.io.read_raw_*</code> function.
+  </Step>
+  <Step title="Use registry in viewer">
+    The viewer consults the registry so dropping in a new plugin automatically enables a new format.
+  </Step>
+</Steps>
+
+<Callout type="warning">
+  Optional readers such as EGI <code>.mff</code> register only if the corresponding <code>mne.io</code> function exists.
+</Callout>
+
+## Verify the plugin system
+
+```bash
+pip install -e .
+pytest -q
+```
+
+<Diagram>
+loader/*.py -> registry -> load_eeg_file -> MNE reader
+</Diagram>

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -2,96 +2,75 @@
 
 import os
 import sys
-from pathlib import Path
 
 import pytest
 import mne
 import numpy as np
 
-from autocleaneeg_view.viewer import load_eeg_file, view_eeg
+import autocleaneeg_view.viewer as viewer
+from autocleaneeg_view.viewer import SUPPORTED_EXTENSIONS, load_eeg_file, view_eeg
+from autocleaneeg_view import loaders
 
 
 @pytest.fixture
-def mock_set_file(tmp_path):
-    """Create a mock .set file path for testing."""
-    return tmp_path / "test_data.set"
+def mock_raw():
+    """Return a simple mock Raw object."""
+    return mne.io.RawArray(
+        np.random.rand(10, 1000), mne.create_info(10, 100, ch_types="eeg")
+    )
 
 
-@pytest.fixture
-def mock_edf_file(tmp_path):
-    """Create a mock .edf file path for testing."""
-    return tmp_path / "test_data.edf"
-
-
-@pytest.fixture
-def mock_bdf_file(tmp_path):
-    """Create a mock .bdf file path for testing."""
-    return tmp_path / "test_data.bdf"
-
-
-def test_load_eeg_file_validates_extension(mock_set_file):
+def test_load_eeg_file_validates_extension(tmp_path):
     """Test that load_eeg_file validates the file extension."""
-    wrong_ext = Path(str(mock_set_file).replace(".set", ".txt"))
+    wrong_ext = tmp_path / "test_data.txt"
+    wrong_ext.touch()
 
-    with pytest.raises(
-        ValueError, match="must have .set, .edf, or .bdf extension"
-    ):
+    with pytest.raises(ValueError) as excinfo:
         load_eeg_file(wrong_ext)
 
+    msg = str(excinfo.value)
+    assert "must have one of" in msg
+    for ext in SUPPORTED_EXTENSIONS:
+        assert ext in msg
 
-def test_load_eeg_file_validates_existence(mock_set_file):
+
+def test_load_eeg_file_validates_existence(tmp_path):
     """Test that load_eeg_file validates file existence."""
+    missing_file = tmp_path / "test_data.set"
     with pytest.raises(FileNotFoundError):
-        load_eeg_file(mock_set_file)  # File doesn't exist yet
+        load_eeg_file(missing_file)  # File doesn't exist yet
 
 
-def test_load_eeg_file_set(monkeypatch, mock_set_file):
-    """Test loading a .set file with a monkey-patched MNE function."""
-    # Create a mock Raw object
-    mock_raw = mne.io.RawArray(np.random.rand(10, 1000), 
-                              mne.create_info(10, 100, ch_types='eeg'))
-    
-    # Monkeypatch mne.io.read_raw_eeglab to return our mock_raw
-    def mock_read_raw_eeglab(*args, **kwargs):
-        return mock_raw
-    
-    monkeypatch.setattr(mne.io, "read_raw_eeglab", mock_read_raw_eeglab)
-    
-    # Create an empty file to pass existence check
-    mock_set_file.touch()
-    
-    # Test loading
-    raw = load_eeg_file(mock_set_file)
-    assert raw is mock_raw
+_PARAMS = [
+    (".set", "read_raw_eeglab", False),
+    (".edf", "read_raw_edf", False),
+    (".bdf", "read_raw_bdf", False),
+    (".vhdr", "read_raw_brainvision", False),
+    (".fif", "read_raw_fif", False),
+    (".raw", "read_raw_egi", False),
+    (".gdf", "read_raw_gdf", False),
+]
+if hasattr(mne.io, "read_raw_mff"):
+    _PARAMS.append((".mff", "read_raw_mff", True))
 
 
-def test_load_eeg_file_edf(monkeypatch, mock_edf_file):
-    """Test loading an .edf file with a monkey-patched MNE function."""
-    mock_raw = mne.io.RawArray(
-        np.random.rand(10, 1000), mne.create_info(10, 100, ch_types="eeg")
-    )
+@pytest.mark.parametrize("ext, loader_name, is_dir", _PARAMS)
+def test_load_eeg_file(monkeypatch, tmp_path, ext, loader_name, is_dir, mock_raw):
+    """Ensure each supported format is loaded with the appropriate reader."""
 
-    def mock_read_raw_edf(*args, **kwargs):
+    def mock_loader(*args, **kwargs):
         return mock_raw
 
-    monkeypatch.setattr(mne.io, "read_raw_edf", mock_read_raw_edf)
-    mock_edf_file.touch()
-    raw = load_eeg_file(mock_edf_file)
-    assert raw is mock_raw
+    # Patch the reader registry so load_eeg_file uses the mock.
+    monkeypatch.setitem(loaders.READERS, ext, mock_loader)
 
+    file_path = tmp_path / f"test{ext}"
+    if is_dir:
+        file_path.mkdir()
+    else:
+        file_path.touch()
 
-def test_load_eeg_file_bdf(monkeypatch, mock_bdf_file):
-    """Test loading a .bdf file with a monkey-patched MNE function."""
-    mock_raw = mne.io.RawArray(
-        np.random.rand(10, 1000), mne.create_info(10, 100, ch_types="eeg")
-    )
-
-    def mock_read_raw_bdf(*args, **kwargs):
-        return mock_raw
-
-    monkeypatch.setattr(mne.io, "read_raw_bdf", mock_read_raw_bdf)
-    mock_bdf_file.touch()
-    raw = load_eeg_file(mock_bdf_file)
+    raw = load_eeg_file(file_path)
     assert raw is mock_raw
 
 
@@ -119,3 +98,4 @@ def test_view_eeg(monkeypatch):
 
     if sys.platform == "darwin":
         assert os.environ.get("QT_QPA_PLATFORM") == "cocoa"
+


### PR DESCRIPTION
## Summary
- split EEG format readers into dedicated plugin modules
- route viewer through central registry and document plugin architecture
- update tests, README, and changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e1673ff48322a26a216cd2971873